### PR TITLE
Show employee attendance details when assigning leads

### DIFF
--- a/lib/features/application/authentification/model/user_profile_model.dart
+++ b/lib/features/application/authentification/model/user_profile_model.dart
@@ -9,6 +9,7 @@ class UserProfileModel {
   final String? freelancerStatus;
   final String? location;
   final String? email; // ✅ New field
+  final String? attendanceStatus;
 
   UserProfileModel({
     this.id,
@@ -21,6 +22,7 @@ class UserProfileModel {
     this.freelancerStatus,
     this.location,
     this.email, // ✅ Added to constructor
+    this.attendanceStatus,
   });
 
   factory UserProfileModel.fromMap(Map<String, dynamic> map) {
@@ -39,6 +41,7 @@ class UserProfileModel {
       freelancerStatus: map['freelancer_status'] as String?,
       location: map['location'] as String?,
       email: map['email'] as String?, // ✅ Added here
+      attendanceStatus: map['attendance_status'] as String?,
     );
   }
 
@@ -54,6 +57,8 @@ class UserProfileModel {
     if (location != null) data['location'] = location;
     if (email != null) data['email'] = email; // ✅ Added here
 
+    // Intentionally skipping attendanceStatus since it's derived from attendance table
+
     return data;
   }
 
@@ -66,6 +71,7 @@ class UserProfileModel {
     String? freelancerStatus,
     String? location,
     String? email, // ✅ Added here
+    String? attendanceStatus,
   }) {
     return UserProfileModel(
       id: id,
@@ -78,6 +84,7 @@ class UserProfileModel {
       freelancerStatus: freelancerStatus ?? this.freelancerStatus,
       location: location ?? this.location,
       email: email ?? this.email, // ✅ Added here
+      attendanceStatus: attendanceStatus ?? this.attendanceStatus,
     );
   }
 }

--- a/lib/features/application/lead_management/controller/lead_management_controller.dart
+++ b/lib/features/application/lead_management/controller/lead_management_controller.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:management_software/features/application/authentification/model/user_profile_model.dart';
 import 'package:management_software/features/application/lead_management/model/lead_management_dto.dart';
 import 'package:management_software/features/data/lead_management/models/lead_info_model.dart';
 import 'package:management_software/features/data/lead_management/models/lead_list_model.dart';
@@ -56,6 +57,27 @@ class LeadController extends StateNotifier<LeadManagementDTO> {
       ref
           .read(snackbarServiceProvider)
           .showError(context, 'Failed to load leads: $e');
+    }
+  }
+
+  Future<List<UserProfileModel>> fetchCounsellors({
+    required BuildContext context,
+    bool forceRefresh = false,
+  }) async {
+    if (state.counsellors.isNotEmpty && !forceRefresh) {
+      return state.counsellors;
+    }
+
+    try {
+      final counsellors = await _leadManagementRepo.fetchCounsellors();
+      state = state.copyWith(counsellors: counsellors);
+      return counsellors;
+    } catch (e) {
+      log('fetchCounsellors error: $e');
+      ref
+          .read(snackbarServiceProvider)
+          .showError(context, 'Failed to load counsellors: $e');
+      return [];
     }
   }
 

--- a/lib/features/application/lead_management/model/lead_management_dto.dart
+++ b/lib/features/application/lead_management/model/lead_management_dto.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:management_software/features/application/authentification/model/user_profile_model.dart';
 import 'package:management_software/features/data/lead_management/models/lead_info_model.dart';
 import 'package:management_software/features/data/lead_management/models/lead_list_model.dart';
 
@@ -10,15 +11,16 @@ class LeadManagementDTO with _$LeadManagementDTO {
   const LeadManagementDTO._();
 
   const factory LeadManagementDTO({
-   @Default([]) List<LeadsListModel> leadsList,
-  @Default([]) List<LeadsListModel> filteredLeadsList,
-  LeadInfoModel? selectedLead,
-  LeadsListModel? selectedLeadLocally,
-  @Default('') String searchQuery,
-  @Default('') String filterSource,
-  @Default('') String filterStatus,
-  @Default('') String filterFreelancer,
-  @Default('') String filterLeadType,
+    @Default([]) List<LeadsListModel> leadsList,
+    @Default([]) List<LeadsListModel> filteredLeadsList,
+    LeadInfoModel? selectedLead,
+    LeadsListModel? selectedLeadLocally,
+    @Default('') String searchQuery,
+    @Default('') String filterSource,
+    @Default('') String filterStatus,
+    @Default('') String filterFreelancer,
+    @Default('') String filterLeadType,
+    @Default([]) List<UserProfileModel> counsellors,
   }) = _LeadManagementDTO;
   
   @override

--- a/lib/features/application/lead_management/model/lead_management_dto.freezed.dart
+++ b/lib/features/application/lead_management/model/lead_management_dto.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$LeadManagementDTO {
 
- List<LeadsListModel> get leadsList; List<LeadsListModel> get filteredLeadsList; LeadInfoModel? get selectedLead; LeadsListModel? get selectedLeadLocally; String get searchQuery; String get filterSource; String get filterStatus; String get filterFreelancer; String get filterLeadType;
+ List<LeadsListModel> get leadsList; List<LeadsListModel> get filteredLeadsList; LeadInfoModel? get selectedLead; LeadsListModel? get selectedLeadLocally; String get searchQuery; String get filterSource; String get filterStatus; String get filterFreelancer; String get filterLeadType; List<UserProfileModel> get counsellors;
 /// Create a copy of LeadManagementDTO
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $LeadManagementDTOCopyWith<LeadManagementDTO> get copyWith => _$LeadManagementDT
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LeadManagementDTO&&const DeepCollectionEquality().equals(other.leadsList, leadsList)&&const DeepCollectionEquality().equals(other.filteredLeadsList, filteredLeadsList)&&(identical(other.selectedLead, selectedLead) || other.selectedLead == selectedLead)&&(identical(other.selectedLeadLocally, selectedLeadLocally) || other.selectedLeadLocally == selectedLeadLocally)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.filterSource, filterSource) || other.filterSource == filterSource)&&(identical(other.filterStatus, filterStatus) || other.filterStatus == filterStatus)&&(identical(other.filterFreelancer, filterFreelancer) || other.filterFreelancer == filterFreelancer)&&(identical(other.filterLeadType, filterLeadType) || other.filterLeadType == filterLeadType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LeadManagementDTO&&const DeepCollectionEquality().equals(other.leadsList, leadsList)&&const DeepCollectionEquality().equals(other.filteredLeadsList, filteredLeadsList)&&(identical(other.selectedLead, selectedLead) || other.selectedLead == selectedLead)&&(identical(other.selectedLeadLocally, selectedLeadLocally) || other.selectedLeadLocally == selectedLeadLocally)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.filterSource, filterSource) || other.filterSource == filterSource)&&(identical(other.filterStatus, filterStatus) || other.filterStatus == filterStatus)&&(identical(other.filterFreelancer, filterFreelancer) || other.filterFreelancer == filterFreelancer)&&(identical(other.filterLeadType, filterLeadType) || other.filterLeadType == filterLeadType)&&const DeepCollectionEquality().equals(other.counsellors, counsellors));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(leadsList),const DeepCollectionEquality().hash(filteredLeadsList),selectedLead,selectedLeadLocally,searchQuery,filterSource,filterStatus,filterFreelancer,filterLeadType);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(leadsList),const DeepCollectionEquality().hash(filteredLeadsList),const DeepCollectionEquality().hash(counsellors),selectedLead,selectedLeadLocally,searchQuery,filterSource,filterStatus,filterFreelancer,filterLeadType);
 
 @override
 String toString() {
-  return 'LeadManagementDTO(leadsList: $leadsList, filteredLeadsList: $filteredLeadsList, selectedLead: $selectedLead, selectedLeadLocally: $selectedLeadLocally, searchQuery: $searchQuery, filterSource: $filterSource, filterStatus: $filterStatus, filterFreelancer: $filterFreelancer, filterLeadType: $filterLeadType)';
+  return 'LeadManagementDTO(leadsList: $leadsList, filteredLeadsList: $filteredLeadsList, selectedLead: $selectedLead, selectedLeadLocally: $selectedLeadLocally, searchQuery: $searchQuery, filterSource: $filterSource, filterStatus: $filterStatus, filterFreelancer: $filterFreelancer, filterLeadType: $filterLeadType, counsellors: $counsellors)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $LeadManagementDTOCopyWith<$Res>  {
   factory $LeadManagementDTOCopyWith(LeadManagementDTO value, $Res Function(LeadManagementDTO) _then) = _$LeadManagementDTOCopyWithImpl;
 @useResult
 $Res call({
- List<LeadsListModel> leadsList, List<LeadsListModel> filteredLeadsList, LeadInfoModel? selectedLead, LeadsListModel? selectedLeadLocally, String searchQuery, String filterSource, String filterStatus, String filterFreelancer, String filterLeadType
+ List<LeadsListModel> leadsList, List<LeadsListModel> filteredLeadsList, LeadInfoModel? selectedLead, LeadsListModel? selectedLeadLocally, String searchQuery, String filterSource, String filterStatus, String filterFreelancer, String filterLeadType, List<UserProfileModel> counsellors
 });
 
 
@@ -62,7 +62,7 @@ class _$LeadManagementDTOCopyWithImpl<$Res>
 
 /// Create a copy of LeadManagementDTO
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? leadsList = null,Object? filteredLeadsList = null,Object? selectedLead = freezed,Object? selectedLeadLocally = freezed,Object? searchQuery = null,Object? filterSource = null,Object? filterStatus = null,Object? filterFreelancer = null,Object? filterLeadType = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? leadsList = null,Object? filteredLeadsList = null,Object? selectedLead = freezed,Object? selectedLeadLocally = freezed,Object? searchQuery = null,Object? filterSource = null,Object? filterStatus = null,Object? filterFreelancer = null,Object? filterLeadType = null,Object? counsellors = null,}) {
   return _then(_self.copyWith(
 leadsList: null == leadsList ? _self.leadsList : leadsList // ignore: cast_nullable_to_non_nullable
 as List<LeadsListModel>,filteredLeadsList: null == filteredLeadsList ? _self.filteredLeadsList : filteredLeadsList // ignore: cast_nullable_to_non_nullable
@@ -73,7 +73,8 @@ as String,filterSource: null == filterSource ? _self.filterSource : filterSource
 as String,filterStatus: null == filterStatus ? _self.filterStatus : filterStatus // ignore: cast_nullable_to_non_nullable
 as String,filterFreelancer: null == filterFreelancer ? _self.filterFreelancer : filterFreelancer // ignore: cast_nullable_to_non_nullable
 as String,filterLeadType: null == filterLeadType ? _self.filterLeadType : filterLeadType // ignore: cast_nullable_to_non_nullable
-as String,
+as String,counsellors: null == counsellors ? _self.counsellors : counsellors // ignore: cast_nullable_to_non_nullable
+as List<UserProfileModel>,
   ));
 }
 
@@ -158,10 +159,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<LeadsListModel> leadsList,  List<LeadsListModel> filteredLeadsList,  LeadInfoModel? selectedLead,  LeadsListModel? selectedLeadLocally,  String searchQuery,  String filterSource,  String filterStatus,  String filterFreelancer,  String filterLeadType)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<LeadsListModel> leadsList,  List<LeadsListModel> filteredLeadsList,  LeadInfoModel? selectedLead,  LeadsListModel? selectedLeadLocally,  String searchQuery,  String filterSource,  String filterStatus,  String filterFreelancer,  String filterLeadType,  List<UserProfileModel> counsellors)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _LeadManagementDTO() when $default != null:
-return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that.selectedLeadLocally,_that.searchQuery,_that.filterSource,_that.filterStatus,_that.filterFreelancer,_that.filterLeadType);case _:
+return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that.selectedLeadLocally,_that.searchQuery,_that.filterSource,_that.filterStatus,_that.filterFreelancer,_that.filterLeadType,_that.counsellors);case _:
   return orElse();
 
 }
@@ -179,10 +180,10 @@ return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<LeadsListModel> leadsList,  List<LeadsListModel> filteredLeadsList,  LeadInfoModel? selectedLead,  LeadsListModel? selectedLeadLocally,  String searchQuery,  String filterSource,  String filterStatus,  String filterFreelancer,  String filterLeadType)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<LeadsListModel> leadsList,  List<LeadsListModel> filteredLeadsList,  LeadInfoModel? selectedLead,  LeadsListModel? selectedLeadLocally,  String searchQuery,  String filterSource,  String filterStatus,  String filterFreelancer,  String filterLeadType,  List<UserProfileModel> counsellors)  $default,) {final _that = this;
 switch (_that) {
 case _LeadManagementDTO():
-return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that.selectedLeadLocally,_that.searchQuery,_that.filterSource,_that.filterStatus,_that.filterFreelancer,_that.filterLeadType);case _:
+return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that.selectedLeadLocally,_that.searchQuery,_that.filterSource,_that.filterStatus,_that.filterFreelancer,_that.filterLeadType,_that.counsellors);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +200,10 @@ return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<LeadsListModel> leadsList,  List<LeadsListModel> filteredLeadsList,  LeadInfoModel? selectedLead,  LeadsListModel? selectedLeadLocally,  String searchQuery,  String filterSource,  String filterStatus,  String filterFreelancer,  String filterLeadType)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<LeadsListModel> leadsList,  List<LeadsListModel> filteredLeadsList,  LeadInfoModel? selectedLead,  LeadsListModel? selectedLeadLocally,  String searchQuery,  String filterSource,  String filterStatus,  String filterFreelancer,  String filterLeadType,  List<UserProfileModel> counsellors)?  $default,) {final _that = this;
 switch (_that) {
 case _LeadManagementDTO() when $default != null:
-return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that.selectedLeadLocally,_that.searchQuery,_that.filterSource,_that.filterStatus,_that.filterFreelancer,_that.filterLeadType);case _:
+return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that.selectedLeadLocally,_that.searchQuery,_that.filterSource,_that.filterStatus,_that.filterFreelancer,_that.filterLeadType,_that.counsellors);case _:
   return null;
 
 }
@@ -214,7 +215,7 @@ return $default(_that.leadsList,_that.filteredLeadsList,_that.selectedLead,_that
 
 
 class _LeadManagementDTO extends LeadManagementDTO {
-  const _LeadManagementDTO({final  List<LeadsListModel> leadsList = const [], final  List<LeadsListModel> filteredLeadsList = const [], this.selectedLead, this.selectedLeadLocally, this.searchQuery = '', this.filterSource = '', this.filterStatus = '', this.filterFreelancer = '', this.filterLeadType = ''}): _leadsList = leadsList,_filteredLeadsList = filteredLeadsList,super._();
+  const _LeadManagementDTO({final  List<LeadsListModel> leadsList = const [], final  List<LeadsListModel> filteredLeadsList = const [], this.selectedLead, this.selectedLeadLocally, this.searchQuery = '', this.filterSource = '', this.filterStatus = '', this.filterFreelancer = '', this.filterLeadType = '', final  List<UserProfileModel> counsellors = const []}): _leadsList = leadsList,_filteredLeadsList = filteredLeadsList,_counsellors = counsellors,super._();
   
 
  final  List<LeadsListModel> _leadsList;
@@ -238,6 +239,12 @@ class _LeadManagementDTO extends LeadManagementDTO {
 @override@JsonKey() final  String filterStatus;
 @override@JsonKey() final  String filterFreelancer;
 @override@JsonKey() final  String filterLeadType;
+ final  List<UserProfileModel> _counsellors;
+@override@JsonKey() List<UserProfileModel> get counsellors {
+  if (_counsellors is EqualUnmodifiableListView) return _counsellors;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_counsellors);
+}
 
 /// Create a copy of LeadManagementDTO
 /// with the given fields replaced by the non-null parameter values.
@@ -249,16 +256,16 @@ _$LeadManagementDTOCopyWith<_LeadManagementDTO> get copyWith => __$LeadManagemen
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LeadManagementDTO&&const DeepCollectionEquality().equals(other._leadsList, _leadsList)&&const DeepCollectionEquality().equals(other._filteredLeadsList, _filteredLeadsList)&&(identical(other.selectedLead, selectedLead) || other.selectedLead == selectedLead)&&(identical(other.selectedLeadLocally, selectedLeadLocally) || other.selectedLeadLocally == selectedLeadLocally)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.filterSource, filterSource) || other.filterSource == filterSource)&&(identical(other.filterStatus, filterStatus) || other.filterStatus == filterStatus)&&(identical(other.filterFreelancer, filterFreelancer) || other.filterFreelancer == filterFreelancer)&&(identical(other.filterLeadType, filterLeadType) || other.filterLeadType == filterLeadType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LeadManagementDTO&&const DeepCollectionEquality().equals(other._leadsList, _leadsList)&&const DeepCollectionEquality().equals(other._filteredLeadsList, _filteredLeadsList)&&(identical(other.selectedLead, selectedLead) || other.selectedLead == selectedLead)&&(identical(other.selectedLeadLocally, selectedLeadLocally) || other.selectedLeadLocally == selectedLeadLocally)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.filterSource, filterSource) || other.filterSource == filterSource)&&(identical(other.filterStatus, filterStatus) || other.filterStatus == filterStatus)&&(identical(other.filterFreelancer, filterFreelancer) || other.filterFreelancer == filterFreelancer)&&(identical(other.filterLeadType, filterLeadType) || other.filterLeadType == filterLeadType)&&const DeepCollectionEquality().equals(other._counsellors, _counsellors));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_leadsList),const DeepCollectionEquality().hash(_filteredLeadsList),selectedLead,selectedLeadLocally,searchQuery,filterSource,filterStatus,filterFreelancer,filterLeadType);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_leadsList),const DeepCollectionEquality().hash(_filteredLeadsList),const DeepCollectionEquality().hash(_counsellors),selectedLead,selectedLeadLocally,searchQuery,filterSource,filterStatus,filterFreelancer,filterLeadType);
 
 @override
 String toString() {
-  return 'LeadManagementDTO(leadsList: $leadsList, filteredLeadsList: $filteredLeadsList, selectedLead: $selectedLead, selectedLeadLocally: $selectedLeadLocally, searchQuery: $searchQuery, filterSource: $filterSource, filterStatus: $filterStatus, filterFreelancer: $filterFreelancer, filterLeadType: $filterLeadType)';
+  return 'LeadManagementDTO(leadsList: $leadsList, filteredLeadsList: $filteredLeadsList, selectedLead: $selectedLead, selectedLeadLocally: $selectedLeadLocally, searchQuery: $searchQuery, filterSource: $filterSource, filterStatus: $filterStatus, filterFreelancer: $filterFreelancer, filterLeadType: $filterLeadType, counsellors: $counsellors)';
 }
 
 
@@ -269,7 +276,7 @@ abstract mixin class _$LeadManagementDTOCopyWith<$Res> implements $LeadManagemen
   factory _$LeadManagementDTOCopyWith(_LeadManagementDTO value, $Res Function(_LeadManagementDTO) _then) = __$LeadManagementDTOCopyWithImpl;
 @override @useResult
 $Res call({
- List<LeadsListModel> leadsList, List<LeadsListModel> filteredLeadsList, LeadInfoModel? selectedLead, LeadsListModel? selectedLeadLocally, String searchQuery, String filterSource, String filterStatus, String filterFreelancer, String filterLeadType
+ List<LeadsListModel> leadsList, List<LeadsListModel> filteredLeadsList, LeadInfoModel? selectedLead, LeadsListModel? selectedLeadLocally, String searchQuery, String filterSource, String filterStatus, String filterFreelancer, String filterLeadType, List<UserProfileModel> counsellors
 });
 
 
@@ -286,7 +293,7 @@ class __$LeadManagementDTOCopyWithImpl<$Res>
 
 /// Create a copy of LeadManagementDTO
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? leadsList = null,Object? filteredLeadsList = null,Object? selectedLead = freezed,Object? selectedLeadLocally = freezed,Object? searchQuery = null,Object? filterSource = null,Object? filterStatus = null,Object? filterFreelancer = null,Object? filterLeadType = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? leadsList = null,Object? filteredLeadsList = null,Object? selectedLead = freezed,Object? selectedLeadLocally = freezed,Object? searchQuery = null,Object? filterSource = null,Object? filterStatus = null,Object? filterFreelancer = null,Object? filterLeadType = null,Object? counsellors = null,}) {
   return _then(_LeadManagementDTO(
 leadsList: null == leadsList ? _self._leadsList : leadsList // ignore: cast_nullable_to_non_nullable
 as List<LeadsListModel>,filteredLeadsList: null == filteredLeadsList ? _self._filteredLeadsList : filteredLeadsList // ignore: cast_nullable_to_non_nullable
@@ -297,7 +304,8 @@ as String,filterSource: null == filterSource ? _self.filterSource : filterSource
 as String,filterStatus: null == filterStatus ? _self.filterStatus : filterStatus // ignore: cast_nullable_to_non_nullable
 as String,filterFreelancer: null == filterFreelancer ? _self.filterFreelancer : filterFreelancer // ignore: cast_nullable_to_non_nullable
 as String,filterLeadType: null == filterLeadType ? _self.filterLeadType : filterLeadType // ignore: cast_nullable_to_non_nullable
-as String,
+as String,counsellors: null == counsellors ? _self._counsellors : counsellors // ignore: cast_nullable_to_non_nullable
+as List<UserProfileModel>,
   ));
 }
 

--- a/lib/features/presentation/pages/lead_management/popups/widgets/common_info_box.dart
+++ b/lib/features/presentation/pages/lead_management/popups/widgets/common_info_box.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:management_software/features/application/authentification/model/user_profile_model.dart';
 import 'package:management_software/features/application/lead_management/controller/lead_management_controller.dart';
 import 'package:management_software/features/data/lead_management/models/lead_list_model.dart';
 import 'package:management_software/features/presentation/pages/lead_management/popups/lead_info_popup.dart';
@@ -25,6 +26,10 @@ class _CommonInfoBoxState extends ConsumerState<CommonInfoBox> {
   late TextEditingController remarksController;
   String? selectedStatus;
   DateTime? selectedFollowUpDate;
+  bool isCounsellorLoading = false;
+  String? counsellorError;
+  List<UserProfileModel> counsellors = const [];
+  String? selectedCounsellorId;
 
   final List<String> statusOptions = [
     "Lead creation",
@@ -49,17 +54,111 @@ class _CommonInfoBoxState extends ConsumerState<CommonInfoBox> {
   void initState() {
     super.initState();
     remarksController = TextEditingController();
+    isCounsellorLoading = true;
 
-    Future.microtask(() async {
-      final leadListDetails =
-          ref.watch(leadMangementcontroller).selectedLeadLocally;
-      if (leadListDetails != null) {
-        selectedStatus = leadListDetails.status;
-        selectedFollowUpDate = parseCustomDate(leadListDetails.followUp);
-        remarksController.text = leadListDetails.remark ?? "";
-      }
-      setState(() {});
+    Future.microtask(_initialiseData);
+  }
+
+  Future<void> _initialiseData() async {
+    _hydrateLeadDetails();
+    await _loadCounsellors();
+  }
+
+  void _hydrateLeadDetails() {
+    final leadState = ref.read(leadMangementcontroller);
+    final leadListDetails = leadState.selectedLeadLocally;
+
+    final initialStatus = leadListDetails?.status;
+    final initialFollowUp = parseCustomDate(leadListDetails?.followUp);
+    final initialRemarks = leadListDetails?.remark ?? "";
+    final initialCounsellorId = _normaliseCounsellorId(leadListDetails?.assignedTo);
+
+    remarksController.text = initialRemarks;
+
+    if (!mounted) return;
+
+    setState(() {
+      selectedStatus = initialStatus;
+      selectedFollowUpDate = initialFollowUp;
+      selectedCounsellorId = initialCounsellorId;
     });
+  }
+
+  Future<void> _loadCounsellors({bool forceRefresh = false}) async {
+    if (!mounted) return;
+
+    setState(() {
+      isCounsellorLoading = true;
+      counsellorError = null;
+    });
+
+    final controller = ref.read(leadMangementcontroller.notifier);
+    final assignedProfile =
+        ref.read(leadMangementcontroller).selectedLeadLocally?.assignedProfile;
+
+    List<UserProfileModel> mergedCounsellors = counsellors;
+    String? errorMessage;
+    String? updatedSelectedId = _normaliseCounsellorId(selectedCounsellorId);
+
+    try {
+      final fetched = await controller.fetchCounsellors(
+        context: context,
+        forceRefresh: forceRefresh,
+      );
+
+      mergedCounsellors = _mergeCounsellors(
+        fetched,
+        assignedProfile,
+      );
+
+      final fallbackId = _normaliseCounsellorId(assignedProfile?.id);
+
+      if (updatedSelectedId == null) {
+        updatedSelectedId = fallbackId;
+      } else if (!mergedCounsellors
+          .any((profile) => profile.id == updatedSelectedId)) {
+        updatedSelectedId = fallbackId ?? updatedSelectedId;
+      }
+    } catch (e, st) {
+      debugPrint('Failed to load counsellors: $e\n$st');
+      errorMessage = 'Failed to load counsellors';
+    }
+
+    if (!mounted) return;
+
+    setState(() {
+      counsellors = mergedCounsellors;
+      selectedCounsellorId = updatedSelectedId;
+      counsellorError = errorMessage;
+      isCounsellorLoading = false;
+    });
+  }
+
+  List<UserProfileModel> _mergeCounsellors(
+    List<UserProfileModel> fetched,
+    UserProfileModel? assignedProfile,
+  ) {
+    final uniqueProfiles = <String, UserProfileModel>{};
+
+    for (final profile in fetched) {
+      final id = _normaliseCounsellorId(profile.id);
+      if (id == null) continue;
+      uniqueProfiles[id] = profile;
+    }
+
+    final assignedId = _normaliseCounsellorId(assignedProfile?.id);
+    if (assignedProfile != null && assignedId != null) {
+      uniqueProfiles.putIfAbsent(assignedId, () => assignedProfile);
+    }
+
+    final results = uniqueProfiles.values.toList()
+      ..sort(
+        (a, b) => _counsellorTitle(a)
+            .toLowerCase()
+            .compareTo(_counsellorTitle(b).toLowerCase()),
+      );
+
+    return results;
   }
 
   @override
@@ -78,6 +177,7 @@ class _CommonInfoBoxState extends ConsumerState<CommonInfoBox> {
             remarksController.text.trim().isNotEmpty
                 ? remarksController.text.trim()
                 : null,
+        assignedTo: _normaliseCounsellorId(selectedCounsellorId),
         followUp:
             selectedFollowUpDate != null
                 ? DateTimeHelper.formatDateForLead(selectedFollowUpDate!)
@@ -148,17 +248,17 @@ class _CommonInfoBoxState extends ConsumerState<CommonInfoBox> {
               ],
             ),
             height10,
-            Row(
-              children: [
-                CommonDropdown(
-                  label: 'Status',
-                  items: statusOptions,
-                  value: selectedStatus,
-                  onChanged: (val) {
-                    setState(() => selectedStatus = val);
-                  },
-                ),
-              ],
+            LeadCounsellorSection(
+              isLoading: isCounsellorLoading,
+              errorText: counsellorError,
+              counsellors: counsellors,
+              selectedId: selectedCounsellorId,
+              onChanged: (value) {
+                setState(() {
+                  selectedCounsellorId = _normaliseCounsellorId(value);
+                });
+              },
+              onRefresh: () => _loadCounsellors(forceRefresh: true),
             ),
             height20,
             // Remarks Title
@@ -202,4 +302,347 @@ class _CommonInfoBoxState extends ConsumerState<CommonInfoBox> {
       ),
     );
   }
+}
+
+class LeadCounsellorSection extends StatelessWidget {
+  final bool isLoading;
+  final String? errorText;
+  final List<UserProfileModel> counsellors;
+  final String? selectedId;
+  final ValueChanged<String?> onChanged;
+  final VoidCallback onRefresh;
+
+  const LeadCounsellorSection({
+    super.key,
+    required this.isLoading,
+    required this.errorText,
+    required this.counsellors,
+    required this.selectedId,
+    required this.onChanged,
+    required this.onRefresh,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return const _CounsellorLoadingRow();
+    }
+
+    final hasError = errorText != null && errorText!.isNotEmpty;
+    final hasCounsellors = counsellors.isNotEmpty;
+
+    final dropdownRow = Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: LeadCounsellorDropdown(
+            counsellors: counsellors,
+            selectedId: _normaliseCounsellorId(selectedId),
+            onChanged: onChanged,
+          ),
+        ),
+        width10,
+        Padding(
+          padding: const EdgeInsets.only(top: 12),
+          child: IconButton(
+            onPressed: onRefresh,
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh counsellors',
+          ),
+        ),
+      ],
+    );
+
+    if (hasError && !hasCounsellors) {
+      return _CounsellorMessageRow(
+        icon: Icons.error_outline,
+        message: errorText!,
+        onRefresh: onRefresh,
+      );
+    }
+
+    if (!hasCounsellors) {
+      return _CounsellorMessageRow(
+        icon: Icons.info_outline,
+        message: 'No counsellors available',
+        onRefresh: onRefresh,
+      );
+    }
+
+    if (hasError) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _CounsellorMessageRow(
+            icon: Icons.error_outline,
+            message: errorText!,
+            onRefresh: onRefresh,
+          ),
+          height10,
+          dropdownRow,
+        ],
+      );
+    }
+
+    return dropdownRow;
+  }
+}
+
+class LeadCounsellorDropdown extends StatelessWidget {
+  final List<UserProfileModel> counsellors;
+  final String? selectedId;
+  final ValueChanged<String?> onChanged;
+
+  const LeadCounsellorDropdown({
+    super.key,
+    required this.counsellors,
+    required this.selectedId,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final dropdownItems = <DropdownMenuItem<String?>>[
+      const DropdownMenuItem<String?>(
+        value: null,
+        child: _CounsellorMenuTile(
+          title: 'Unassigned',
+          subtitle: 'No counsellor assigned',
+        ),
+      ),
+      ...counsellors.map(
+        (profile) => DropdownMenuItem<String?>(
+          value: _normaliseCounsellorId(profile.id),
+          child: _CounsellorMenuTile(
+            title: _counsellorTitle(profile),
+            subtitle: _counsellorSubtitle(profile),
+          ),
+        ),
+      ),
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      child: DropdownButtonFormField<String?>(
+        value: _normaliseCounsellorId(selectedId),
+        isExpanded: true,
+        items: dropdownItems,
+        onChanged: onChanged,
+        decoration: InputDecoration(
+          labelText: 'Assigned Counsellor',
+          labelStyle: myTextstyle(color: Colors.grey, fontSize: 16),
+          isDense: true,
+          contentPadding:
+              const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: const BorderSide(color: Colors.grey, width: 1),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: const BorderSide(color: Colors.grey, width: 1.5),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: const BorderSide(color: Colors.grey, width: 1),
+          ),
+        ),
+        selectedItemBuilder: (context) => [
+          const _SelectedCounsellorLabel(
+            title: 'Unassigned',
+            subtitle: 'No counsellor assigned',
+          ),
+          ...counsellors.map(
+            (profile) => _SelectedCounsellorLabel(
+              title: _counsellorTitle(profile),
+              subtitle: _counsellorSubtitle(profile),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CounsellorMenuTile extends StatelessWidget {
+  final String title;
+  final String subtitle;
+
+  const _CounsellorMenuTile({
+    required this.title,
+    required this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          title,
+          style: myTextstyle(fontSize: 16, color: Colors.black),
+          overflow: TextOverflow.ellipsis,
+        ),
+        if (subtitle.isNotEmpty)
+          Text(
+            subtitle,
+            style: myTextstyle(fontSize: 14, color: Colors.grey.shade600),
+            overflow: TextOverflow.ellipsis,
+          ),
+      ],
+    );
+  }
+}
+
+class _SelectedCounsellorLabel extends StatelessWidget {
+  final String title;
+  final String subtitle;
+
+  const _SelectedCounsellorLabel({
+    required this.title,
+    required this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            title,
+            style: myTextstyle(fontSize: 16, color: Colors.black),
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (subtitle.isNotEmpty)
+            Text(
+              subtitle,
+              style: myTextstyle(fontSize: 13, color: Colors.grey.shade600),
+              overflow: TextOverflow.ellipsis,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CounsellorMessageRow extends StatelessWidget {
+  final IconData icon;
+  final String message;
+  final VoidCallback onRefresh;
+
+  const _CounsellorMessageRow({
+    required this.icon,
+    required this.message,
+    required this.onRefresh,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      child: Row(
+        children: [
+          Icon(icon, color: Colors.grey.shade600),
+          width10,
+          Expanded(
+            child: Text(
+              message,
+              style: myTextstyle(color: Colors.grey.shade700, fontSize: 16),
+            ),
+          ),
+          IconButton(
+            onPressed: onRefresh,
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh counsellors',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CounsellorLoadingRow extends StatelessWidget {
+  const _CounsellorLoadingRow();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      child: Row(
+        children: [
+          const SizedBox(
+            height: 20,
+            width: 20,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          width10,
+          Expanded(
+            child: Text(
+              'Loading counsellors…',
+              style: myTextstyle(color: Colors.grey.shade700, fontSize: 16),
+            ),
+          ),
+          const SizedBox(width: 48),
+        ],
+      ),
+    );
+  }
+}
+
+String? _normaliseCounsellorId(String? id) {
+  final trimmed = id?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return null;
+  }
+  return trimmed;
+}
+
+String _counsellorTitle(UserProfileModel profile) {
+  final displayName = profile.displayName?.trim();
+  if (displayName != null && displayName.isNotEmpty) {
+    return displayName;
+  }
+
+  final email = profile.email?.trim();
+  if (email != null && email.isNotEmpty) {
+    return email;
+  }
+
+  final id = profile.id?.trim();
+  if (id != null && id.isNotEmpty) {
+    return id;
+  }
+
+  return 'Unknown Counsellor';
+}
+
+String _counsellorSubtitle(UserProfileModel profile) {
+  final metadata = <String>[];
+
+  final designation = profile.designation?.trim();
+  if (designation != null && designation.isNotEmpty) {
+    metadata.add(designation);
+  }
+
+  final attendance = profile.attendanceStatus?.trim();
+  if (attendance != null && attendance.isNotEmpty) {
+    metadata.add('Attendance: $attendance');
+  } else {
+    metadata.add('Attendance: Not marked');
+  }
+
+  if (metadata.isNotEmpty) {
+    return metadata.join(' • ');
+  }
+
+  final email = profile.email?.trim();
+  if (email != null && email.isNotEmpty) {
+    return email;
+  }
+
+  return '';
 }


### PR DESCRIPTION
## Summary
- hydrate lead status, follow-up, and assigned counsellor details before loading the full employee list and reuse the cached fetch on refreshes
- add dedicated LeadCounsellorSection and LeadCounsellorDropdown widgets so availability, loading, and retry states render cleanly inside the common info box
- render counsellor entries with combined name, designation, and attendance details while surfacing unassigned and refresh affordances for a polished reassignment experience

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d11c0fbc90832fa8e688654031aaf8